### PR TITLE
throw error when input has length zero.

### DIFF
--- a/src/fftw.c
+++ b/src/fftw.c
@@ -161,6 +161,10 @@ SEXP FFT_execute(SEXP s_plan, SEXP s_x, SEXP s_inv) {
 
   /* Extract input vector: */
   n = length(s_x);
+  if (n < 1) {
+    error("Input has length zero.");
+    return R_NilValue;
+  }
   if (n != plan->size) {
     error("Input and plan size differ.");
     return R_NilValue;
@@ -265,6 +269,10 @@ SEXP DCT_execute(SEXP s_plan, SEXP s_x, SEXP s_inv) {
 
   /* Extract input vector: */
   n = length(s_x);
+  if (n < 1) {
+    error("Input has length zero.");
+    return R_NilValue;
+  }
   if (n != plan->size) {
     error("Input and plan size differ.");
     return R_NilValue;


### PR DESCRIPTION
fftw::FFT(numeric()) abort R session.
I encountered a cenario where I am filtering all my data out and pass numeric(0) to FFT() and this killed my R Session.
![grafik](https://github.com/olafmersmann/fftw/assets/138801124/20540e27-5415-4034-9465-2dd323a6f56f)
It would be nice, that the function trows an error insteat.